### PR TITLE
Add 'Artists' field to 'Track'

### DIFF
--- a/models.go
+++ b/models.go
@@ -42,6 +42,7 @@ type Track struct {
 	Title        string         `json:"title"`
 	Type         string         `json:"type_"`
 	Extraartists []ArtistSource `json:"extraartists"`
+	Artists      []ArtistSource `json:"artists"`
 }
 
 // LabelSource ...


### PR DESCRIPTION
Some tracks contain different artists than specified in the release. In
this case there is a field 'artists' in the JSON response. This field is
added to the 'Track' struct. When the field 'artists' is available in the
JSON response, the length of 'Artists' is not 0. Otherwise the 'Artists'
from the release should be used.

Signed-off-by: Philip Luyckx <philip.luyckx@gmail.com>