### PR TITLE
Update search example for current code behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ type SearchRequest struct {
 Example
 ```go
   request := discogs.SearchRequest{Artist: "reggaenauts", ReleaseTitle: "river rock", Page: 0, PerPage: 1}
-  search, _ := client.Search(request)
+  search, _ := client.Search.Search(request)
 
   for _, r := range search.Results {
     fmt.Println(r.Title)


### PR DESCRIPTION
Looking at discogs_example.go it appears the call to the function is .Search.Search