### PR TITLE
add cover_image to search results

### DIFF
--- a/search.go
+++ b/search.go
@@ -80,6 +80,7 @@ type Search struct {
 type Result struct {
 	Style       []string  `json:"style,omitempty"`
 	Thumb       string    `json:"thumb,omitempty"`
+	CoverImage  string    `json:"cover_image,omitempty"`
 	Title       string    `json:"title,omitempty"`
 	Country     string    `json:"country,omitempty"`
 	Format      []string  `json:"format,omitempty"`


### PR DESCRIPTION
cover_image is a larger size image that is returned in the search
results and it is useful in my particular case, hopefully it will be
useful for others as well