### PR TITLE
Add Notes struct to fix CollectionItemSource.Notes field

### DIFF
--- a/models.go
+++ b/models.go
@@ -187,6 +187,12 @@ type ReleaseSource struct {
 	Type        string `json:"type"`
 }
 
+// Notes ...
+type Notes struct {
+	FieldID int    `json:"field_id"`
+	Value   string `json:"value"`
+}
+
 // Pagination ...
 type Pagination struct {
 	// TODO(irlndts): validate requested Sort

--- a/user_collection.go
+++ b/user_collection.go
@@ -67,7 +67,7 @@ type CollectionItemSource struct {
 	DateAdded        string           `json:"date_added"`
 	FolderID         int              `json:"folder_id,omitempty"`
 	InstanceID       int              `json:"instance_id"`
-	Notes            string           `json:"notes,omitempty"`
+	Notes            []Notes          `json:"notes,omitempty"`
 	Rating           int              `json:"rating"`
 }
 


### PR DESCRIPTION
Hello!

I'm getting the error `json: cannot unmarshal array into Go struct field CollectionItemSource.releases.notes of type string` whenever trying to get Collection items from the Discogs.

According to the documentation, the Notes is not a `string` anymore https://www.discogs.com/developers/#page:user-collection,header:user-collection-collection-items-by-folder it returns an array now.

The pull request adds a new Notes struct and updates the data type for CollectionItemSource.Notes field.